### PR TITLE
fix for 5.7 cpu up/down api change

### DIFF
--- a/corefreqk.c
+++ b/corefreqk.c
@@ -10361,10 +10361,15 @@ static long CoreFreqK_ioctl(	struct file *filp,
 	unsigned int cpu = (unsigned int) arg;
 
 	if (cpu < Proc->CPU.Count) {
-		if (!cpu_is_hotpluggable(cpu))
+		if (!cpu_is_hotpluggable(cpu)) {
 			rc = -EINVAL;
-		else
+		} else {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+			rc = remove_cpu(cpu);
+#else
 			rc = cpu_down(cpu);
+#endif
+		}
 	    }
 	}
     #else
@@ -10378,10 +10383,15 @@ static long CoreFreqK_ioctl(	struct file *filp,
 	unsigned int cpu = (unsigned int) arg;
 
 	if (cpu < Proc->CPU.Count) {
-		if (!cpu_is_hotpluggable(cpu))
+		if (!cpu_is_hotpluggable(cpu)) {
 			rc = -EINVAL;
-		else
+		} else {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+			rc = add_cpu(cpu);
+#else
 			rc = cpu_up(cpu);
+#endif
+		}
 	    }
 	}
     #else


### PR DESCRIPTION
Unsure how long the add/remove_cpu APIs have actually been around but in the interest of just getting it working here is at least a fix that should not regress. (in an ideal world there are no regressions of course so ok) but please do review and fix whatever looks best I just noticed its still an issue in master a few weeks later