### PR TITLE
Add auto load/unload module to corefreqd.service

### DIFF
--- a/corefreqd.service
+++ b/corefreqd.service
@@ -7,8 +7,10 @@ Description=CoreFreq Daemon
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/modprobe corefreqk
 ExecStart=/bin/corefreqd -q
 ExecStop=/bin/kill -QUIT $MAINPID
+ExecStopPost=/usr/bin/modprobe -r corefreqk
 RemainAfterExit=no
 SuccessExitStatus=SIGQUIT SIGUSR1 SIGTERM
 


### PR DESCRIPTION
This adds two lines to the `corefreqd.service` systemd unit so it will automatically load the kernel module when starting and unload the module when stopping.