### PR TITLE
[CI] Pin build environment to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
 
     strategy:


### PR DESCRIPTION
ubuntu-latest has been updated to ubuntu-24.04 (https://github.com/actions/runner-images/issues/10636).
In contrast, the run-on-arch-action (https://github.com/uraimo/run-on-arch-action) is still utilizing ubuntu-22.04.

